### PR TITLE
Listen for redis client results and throw error on failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,16 @@ RedisStore.prototype.set = function (key, value, lifetime, callback) {
 	if (lifetime > 0) {
 		multi.expire(redisKey, lifetime);
 	}
-	multi.exec(function (err, data) {
+	var ok = multi.exec(function (err, data) {
 		typeof callback == 'function' && callback.call(this, null);
 	});
+	if (!ok) {
+		var err = new Error('Failed redis request');
+		typeof callback == 'function' && callback(err, null);
+	}
 };
 RedisStore.prototype.get = function (key, callback) {
-	this.client.get(this.options.prefix+key, function (err, data) {
+	var ok = this.client.get(this.options.prefix+key, function (err, data) {
 		if (err) {
 			typeof callback == 'function' && callback(err, null);
 		} else {
@@ -48,11 +52,19 @@ RedisStore.prototype.get = function (key, callback) {
 			typeof callback == 'function' && callback(err, data);
 		}
 	});
+	if (!ok) {
+		var err = new Error('Failed redis request');
+		typeof callback == 'function' && callback(err, null);
+	}
 };
 RedisStore.prototype.reset = function (key, callback) {
-	this.client.del(this.options.prefix+key, function (err, data) {
+	var ok = this.client.del(this.options.prefix+key, function (err, data) {
 		typeof callback == 'function' && callback.apply(this, arguments);
 	});
+	if (!ok) {
+		var err = new Error('Failed redis request');
+		typeof callback == 'function' && callback(err, null);
+	}
 };
 RedisStore.Redis = Redis;
 RedisStore.defaults = {

--- a/mock/RedisMock.js
+++ b/mock/RedisMock.js
@@ -24,6 +24,7 @@ RedisClientMock.prototype.expire = function (key, lifetime, callback) {
 };
 RedisClientMock.prototype.get = function (key, callback) {
 	typeof callback == 'function' && callback(null, this.data[key] && this.data[key].value);
+	return 1;
 };
 RedisClientMock.prototype.del = function (key, callback) {
 	if (this.data[key] && this.data[key].timeout) {
@@ -31,6 +32,7 @@ RedisClientMock.prototype.del = function (key, callback) {
 	}
 	delete this.data[key];
 	typeof callback == 'function' && callback(null);
+	return 1;
 };
 RedisClientMock.prototype.multi = function (key, callback) {
 	return new RedisMultiMock(this);
@@ -75,6 +77,7 @@ RedisMultiMock.prototype = {
 			callback(this.err, this.responses);
 		}, this);
 		setTimeout(_.bind(function () { this.runQueue(); }, this));
+		return 1;
 	},
 	_createCallback: function (callback) {
 		return _.bind(function (err, response) {


### PR DESCRIPTION
When using `express-brute` backed by `express-brute-redis` as the store I ran in to problems when my redis server would become inaccessible (for some temporary network glitch or something similar).

I would have assumed that an inaccessible store would throw errors that could be handled by `express-brute`'s `handleStoreError` but it turned out that some redis store errors failed silently. Instead the request to the store stalled, which then led to the bruteforce check stalling and finally the http request stalling when the redis server is inaccessible.

So, here is a fix for that. It throws more errors than the original solution, namely when the reply from the redis client is falsy (so this is different from any response coming from a successful request/response loop that actually hits the redis server.)

(I also updated the `RedisMock` file so that the tests are passing.)

Let me know if you need more information.
